### PR TITLE
Bugfix/work order create workflow

### DIFF
--- a/pico_mrp/models/mrp.py
+++ b/pico_mrp/models/mrp.py
@@ -159,7 +159,7 @@ class MRPPicoWorkOrder(models.Model):
     def _pico_create(self):
         api = pico_api(self.env)
         process_result = api.create_work_order(self.process_id.pico_id,
-                                               self.production_id.pico_workflow_version_id.pico_id,
+                                               self.process_id.workflow_id.version_ids.pico_id,
                                                self.production_id.name)
         self.write({
             'pico_id': process_result['id'],


### PR DESCRIPTION
ISSUE work order create was failing on unknown production.workflow_version_id

FIX use process.version_ids.pico_id to get workflow version id for work order create
