### PR TITLE
delete work orders on MO cancel

### DIFF
--- a/pico_mrp/models/api/pico_requests.py
+++ b/pico_mrp/models/api/pico_requests.py
@@ -19,6 +19,11 @@ class PicoMESRequest:
         result.raise_for_status()
         return result.json()
 
+    def delete_request(self, endpoint):
+        url = self.url + endpoint
+        result = requests.delete(url, headers=self.headers)
+        result.raise_for_status()
+
     def subscribe_jsonrpc(self, endpoint_url, new_workflow_version_method, work_order_complete_method):
         body = {
             'rpcHostUrl': endpoint_url,
@@ -30,3 +35,6 @@ class PicoMESRequest:
     def create_work_order(self, process_id, workflow_version_id, annotation=''):
         body = {"processId": process_id, 'workflowVersionId': workflow_version_id, 'annotation': annotation}
         return self.post_request('/work_orders', body)
+
+    def delete_work_order(self, work_order_id):
+        return self.delete_request('/work_orders/' + work_order_id)

--- a/pico_mrp/models/mrp.py
+++ b/pico_mrp/models/mrp.py
@@ -28,6 +28,17 @@ class MRPProduction(models.Model):
             production._pico_create_work_orders()
         return res
 
+    def _pico_delete_work_orders(self):
+        for work_order in self.pico_work_order_ids:
+          work_order.pico_delete()
+        self.pico_work_order_ids.unlink()
+
+    def action_cancel(self):
+        res = super().action_cancel()
+        for production in self.filtered(lambda l: l.pico_process_id):
+            production._pico_delete_work_orders()
+        return res
+
     def pico_validate_bom_setup(self):
         self.bom_id.pico_workflow_id.validate_bom_setup(self.bom_id, should_raise=True)
 
@@ -161,6 +172,13 @@ class MRPPicoWorkOrder(models.Model):
             'pico_id': process_result['id'],
             'state': 'running',
         })
+
+    def pico_delete(self):
+        self._pico_delete()
+
+    def _pico_delete(self):
+        api = pico_api(self.env)
+        api.delete_work_order(self.pico_id)
 
     def _workorder_should_consume_in_real_time(self):
         # 1. Must be making a single 'unit' qty

--- a/pico_mrp/models/mrp.py
+++ b/pico_mrp/models/mrp.py
@@ -30,7 +30,7 @@ class MRPProduction(models.Model):
 
     def _pico_delete_work_orders(self):
         for work_order in self.pico_work_order_ids:
-          work_order.pico_delete()
+            work_order.pico_delete()
         self.pico_work_order_ids.unlink()
 
     def action_cancel(self):


### PR DESCRIPTION
Note: I haven't been able to verify that MO's created by Replenish To Order (name in community edition I have)/Make To Order would successfully delete when the origin is cancelled.  I can't seem to get the child MOs to cancel at all.  Manually cancelling them does also delete the work orders FWIW.