### PR TITLE
When cancelling an MO, only delete unfinished Pico work orders.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,8 @@ services:
       - "todoopgdata:/var/lib/postgresql/data/pgdata"
 
   todoo:
-    command: /opt/odoo/pico/test.sh
     <<: *odoo
+    command: /opt/odoo/pico/test.sh
     depends_on:
       - tdb
     ports:

--- a/pico_mrp/models/mrp.py
+++ b/pico_mrp/models/mrp.py
@@ -33,9 +33,10 @@ class MRPProduction(models.Model):
         return res
 
     def _pico_delete_work_orders(self):
-        for work_order in self.pico_work_order_ids:
+        incomplete_work_orders = self.pico_work_order_ids.filtered(lambda wo: wo.state != "done")
+        for work_order in incomplete_work_orders:
             work_order.pico_delete()
-        self.pico_work_order_ids.unlink()
+            work_order.unlink()
 
     def action_cancel(self):
         res = super().action_cancel()


### PR DESCRIPTION
Right now when an MO gets cancelled, we delete all work orders regardless of whether or not they've been completed. This results in any completed builds in Pico with an associated work order from MO to no longer show that MO/WO in the Pico assembly data view. 

Before cancelling, 1 WO is complete:
![image](https://user-images.githubusercontent.com/2513422/153609320-0d6d9ab5-164e-4c5c-abb2-2d30d7dfca29.png)

After cancelling, 1 completed WO remains:
![image](https://user-images.githubusercontent.com/2513422/153609398-2984a324-264b-43c0-8241-7aa975caffe7.png)
