### PR TITLE
Save work order cycle times (sent over as an integer in milliseconds).

### DIFF
--- a/pico_mrp/models/mrp.py
+++ b/pico_mrp/models/mrp.py
@@ -162,6 +162,7 @@ class MRPPicoWorkOrder(models.Model):
     ], string='State', default='draft')
     date_start = fields.Datetime(string='Started At')
     date_complete = fields.Datetime(string='Completed At')
+    cycle_time = fields.Integer(string='Cycle Time')
     attr_value_ids = fields.One2many('mrp.pico.work.order.attr.value', 'work_order_id', string='Attr. Values')
     build_url = fields.Char()
     show_build_url = fields.Boolean()
@@ -230,6 +231,8 @@ class MRPPicoWorkOrder(models.Model):
             write_vals['date_start'] = process_datetime(values['startedAt'])
         if 'completedAt' in values:
             write_vals['date_complete'] = process_datetime(values['completedAt'])
+        if 'cycleTime' in values:
+            write_vals['cycle_time'] = values['cycleTime']
         if 'buildUrl' in values:
             write_vals['build_url'] = values['buildUrl']
             write_vals['show_build_url'] = values['buildUrl'] != ""

--- a/pico_mrp/tests/test_pico_workflow.py
+++ b/pico_mrp/tests/test_pico_workflow.py
@@ -275,7 +275,7 @@ class TestWorkflow(TransactionCase):
             ],
             "startedAt": "2020-10-01T10:40:50.043Z",
             "completedAt": "2020-10-02T10:40:50.043Z",
-            "cycleTime": 0,
+            "cycleTime": 123456,
             "workflowId": "string",
             "processId": "string",
             "workOrderId": "string"
@@ -284,6 +284,7 @@ class TestWorkflow(TransactionCase):
         self.assertEqual(mo.pico_work_order_ids.state, 'done')
         self.assertEqual(mo.pico_work_order_ids.date_start, datetime(2020, 10, 1, 10, 40, 50))
         self.assertEqual(mo.pico_work_order_ids.date_complete, datetime(2020, 10, 2, 10, 40, 50))
+        self.assertEqual(mo.pico_work_order_ids.cycle_time, 123456)
         for sm in mo.move_raw_ids:
             self.assertEqual(sm.quantity_done, sm.product_uom_qty)
         self.assertEqual(mo.state, 'done')
@@ -394,7 +395,7 @@ class TestWorkflow(TransactionCase):
             ],
             "startedAt": "2020-10-01T10:40:50.043Z",
             "completedAt": "2020-10-02T10:40:50.043Z",
-            "cycleTime": 0,
+            "cycleTime": 123456,
             "workflowId": "string",
             "processId": "string",
             "workOrderId": "string"
@@ -403,6 +404,7 @@ class TestWorkflow(TransactionCase):
         self.assertEqual(work_order1.state, 'pending')
         self.assertEqual(work_order1.date_start, datetime(2020, 10, 1, 10, 40, 50))
         self.assertEqual(work_order1.date_complete, datetime(2020, 10, 2, 10, 40, 50))
+        self.assertEqual(work_order1.cycle_time, 123456)
         self.assertEqual(work_order2.state, 'running')
 
         # because this MO was for 1.0 and all the lot/serial products are 1.0 qty,
@@ -425,7 +427,7 @@ class TestWorkflow(TransactionCase):
             ],
             "startedAt": "2020-10-03T10:40:50.043Z",
             "completedAt": "2020-10-04T10:40:50.043Z",
-            "cycleTime": 0,
+            "cycleTime": 654321,
             "workflowId": "string",
             "processId": "string",
             "workOrderId": "string"
@@ -434,6 +436,7 @@ class TestWorkflow(TransactionCase):
         self.assertEqual(work_order2.state, 'done')
         self.assertEqual(work_order2.date_start, datetime(2020, 10, 3, 10, 40, 50))
         self.assertEqual(work_order2.date_complete, datetime(2020, 10, 4, 10, 40, 50))
+        self.assertEqual(work_order2.cycle_time, 654321)
 
         self.assertEqual(mo.state, 'done')
         self.assertEqual(mo.mapped('move_raw_ids.move_line_ids.qty_done'), [1.0], 'We over consumed.')

--- a/pico_mrp/views/mrp_views.xml
+++ b/pico_mrp/views/mrp_views.xml
@@ -16,6 +16,7 @@
                             <field name="process_id"/>
                             <field name="date_start"/>
                             <field name="date_complete"/>
+                            <field name="cycle_time"/>
                             <field name="state"/>
                             <field name="attr_value_ids" widget="many2many_tags"/>
                             <field name="process_version"/>


### PR DESCRIPTION
Requires an app upgrade adding the new field on the model.

Example view of the new Pico work order column in Odoo v13:

![image](https://user-images.githubusercontent.com/2513422/175054461-94a28949-aadb-453d-9d56-656950693ab0.png)

And then once completed:

![image](https://user-images.githubusercontent.com/2513422/175054530-1f1dbb8d-efa6-414c-9e21-9941982c6d1a.png)
